### PR TITLE
Re-export EcomEvent, EcomStep, EcomView from package root (2.0.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wayke-se/ecom-web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wayke-se/ecom-web",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@wayke-se/ecom": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayke-se/ecom-web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Wayke Ecom Web",
   "type": "module",
   "module": "dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import WaykeEcomWeb from './App';
 
+export { EcomEvent, EcomStep, EcomView } from './Utils/ecomEvent';
+
 export default WaykeEcomWeb;


### PR DESCRIPTION
Intent: Surfaced by a consumer integration: with 2.0.0, code that
  previously imported these enums via the deep path
  `@wayke-se/ecom-web/src/Utils/ecomEvent` had to switch to
  `@wayke-se/ecom-web/dist/Utils/ecomEvent` because the published
  tarball only includes `dist/`. Forcing consumers to reach into our
  internal directory layout is a leaky abstraction -- if we change
  build systems again (the previous switch from npm-dts to tsc nearly
  could have shifted output paths), every consumer breaks.
Decision: Re-export the three event enums from src/index.ts so
  consumers can do `import { EcomEvent, EcomStep, EcomView } from
  '@wayke-se/ecom-web'`. Patch bump since this is purely additive --
  the default export is unchanged, no existing import paths break.
Scope: Limited to the three event enums (the actual reported gap).
  Other exports (EcomSdkConfig, MarketCode, registerEventListner,
  etc.) are not re-exported here -- each becomes officially supported
  API surface with deprecation cost, so they should be added on
  demonstrated need rather than speculatively.